### PR TITLE
(fix) Broken package references after renaming

### DIFF
--- a/packages/ergo-cli/bin/ergoc.js
+++ b/packages/ergo-cli/bin/ergoc.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const Commands = require('../lib/commands');
-const Logger = require('ergo-compiler/lib/logger');
+const Logger = require('@accordproject/ergo-compiler/lib/logger');
 
 require('yargs')
     .command('compile', 'compile Ergo to JavaScript', (yargs) => {

--- a/packages/ergo-cli/bin/ergop.js
+++ b/packages/ergo-cli/bin/ergop.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const Commands = require('../lib/commands');
-const Logger = require('ergo-compiler/lib/logger');
+const Logger = require('@accordproject/ergo-compiler/lib/logger');
 
 require('yargs')
     .command('parse', 'parse CTO file to JSON', (yargs) => {

--- a/packages/ergo-cli/lib/commands.js
+++ b/packages/ergo-cli/lib/commands.js
@@ -15,8 +15,8 @@
 'use strict';
 
 const Fs = require('fs');
-const Ergo = require('ergo-compiler/lib/ergo');
-const ErgoEngine = require('ergo-engine/lib/ergo-engine');
+const Ergo = require('@accordproject/ergo-compiler/lib/ergo');
+const ErgoEngine = require('@accordproject/ergo-engine/lib/ergo-engine');
 
 /**
  * Utility class that implements the commands exposed by the Ergo CLI.

--- a/packages/ergo-cli/package.json
+++ b/packages/ergo-cli/package.json
@@ -24,11 +24,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@accordproject/ergo-compiler": "^0.0.37",
-    "@accordproject/ergo-engine": "^0.0.37",
-    "composer-common": "0.17.4",
-    "moment": "^2.20.1",
-    "vm2": "^3.5.0",
+    "@accordproject/ergo-compiler": "0.0.37",
+    "@accordproject/ergo-engine": "0.0.37",
     "yargs": "^9.0.1"
   },
   "bin": {
@@ -37,11 +34,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "chai-as-promised": "^6.0.0",
     "chai-things": "^0.2.0",
     "eslint": "^4.6.1",
-    "jsdoc": "^3.5.5",
-    "lerna": "^2.5.1",
     "license-check": "^1.1.5",
     "mocha": "^3.4.2",
     "nyc": "^11.3.0"

--- a/packages/ergo-engine/lib/ergo-engine.js
+++ b/packages/ergo-engine/lib/ergo-engine.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const Ergo=require('ergo-compiler/lib/ergo');
+const Ergo=require('@accordproject/ergo-compiler/lib/ergo');
 const Fs = require('fs');
 const Path = require('path');
 const Moment = require('moment');


### PR DESCRIPTION
Add @accordproject prefix scope to ergo packages. 
Remove unused packages