### PR TITLE
Revert "Add CNAME file"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-ergo.accordproject.org


### PR DESCRIPTION
Reverts accordproject/ergo#82 in favor of https://github.com/accordproject/ergo/commit/f7c8ebdb724d86c3d34c68755b028f554e0047ef