### PR TITLE
Fix chrome insecure warning

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -15,8 +15,8 @@
   <body>
     <div class="wrapper">
       <header>
-	<img src="{{ site.github.url }}/ergologo.png"/>
-        <a href="{{ site.github.url }}"> <h1>{{ default: site.github.repository_name }}</h1> </a>
+	<img src="{{ site.github.url | replace: 'http://', 'https://' }}/ergologo.png"/>
+        <a href="{{ site.github.url | replace: 'http://', 'https://' }}"> <h1>{{ default: site.github.repository_name }}</h1> </a>
         <p>{{ site.description | default: site.github.project_tagline }}</p>
 
         {% if site.github.is_project_page %}


### PR DESCRIPTION
https is not officially supported by github pages for custom domains, and consequently it looks like [site.github.url](https://github.com/accordproject/ergo/blob/master/docs/_layouts/default.html#L18) is a link with insecure http protocol.

When a page served over `https` contains an `http` link, Chrome complains that the page is not fully secure, which can be annoying to webpage users.

I found that there is a workaround described in [this issue](https://github.com/github/pages-gem/issues/238).

![screen shot 2018-04-20 at 8 32 33 pm](https://user-images.githubusercontent.com/5581195/39079121-1adb5790-44da-11e8-85d8-2784ba8ea10c.png)


