### PR TITLE
Scripts for manual release

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -61,7 +61,7 @@ else
     _exit "Unknown build focus" 1 
 fi
 
-## Stable releases only; both latest and next then clean up git, and bump version number
+## Stable releases only
 if [[ "${BUILD_RELEASE}" = "stable" ]]; then
 
     # Configure the Git repository and clean any untracked and unignored build files.
@@ -71,8 +71,8 @@ if [[ "${BUILD_RELEASE}" = "stable" ]]; then
     git reset --hard
     git clean -d -f
 
-    # Bump the version number.
-    npm run pkgbump
+    # Set the version number.
+    npm run pkgset ${TRAVIS_TAG}
     export NEW_VERSION=$(node -e "console.log(require('${DIR}/package.json').version)")
 
     # Add the version number changes and push them to Git.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pkgcheck": "node ./scripts/pkgcheck.js",
     "pkgstamp": "node ./scripts/pkgstamp.js",
     "pkgbump": "node ./scripts/pkgbump.js && node ./scripts/pkgcheck.js --fix",
+    "pkgset": "node ./scripts/pkgset.js",
     "depcheck": "node ./scripts/depcheck.js"
   },
   "repository": {

--- a/scripts/pkgset.js
+++ b/scripts/pkgset.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver')
+
+const lernaDirectory = path.resolve('.');
+const lernaConfigFile = path.resolve(lernaDirectory, 'lerna.json');
+const lernaConfig = require(lernaConfigFile);
+lernaConfig.version.replace(/-.*/, '');
+const targetVersion = semver.clean(process.argv[2]);
+lernaConfig.version = targetVersion;
+fs.writeFileSync(lernaConfigFile, JSON.stringify(lernaConfig, null, 2), 'utf8');
+
+const masterPackageFile = path.resolve(lernaDirectory, 'package.json');
+const masterPackage = require(masterPackageFile);
+masterPackage.version = targetVersion;
+fs.writeFileSync(masterPackageFile, JSON.stringify(masterPackage, null, 2), 'utf8');
+
+const packagesDirectory = path.resolve(lernaDirectory, 'packages');
+const packageNames = fs.readdirSync(packagesDirectory);
+const packages = {};
+packageNames.forEach((packageName) => {
+    const packageFile = path.resolve(packagesDirectory, packageName, 'package.json');
+    const thisPackage = require(packageFile);
+    thisPackage.version = targetVersion;
+    packages[packageName] = thisPackage;
+});
+
+for (const i in packages) {
+    const currentPackage = packages[i];
+    for (const j in packages) {
+        const otherPackage = packages[j];
+        for (const dependency in currentPackage.dependencies) {
+            const currentValue = currentPackage.dependencies[dependency];
+            if (dependency === otherPackage.name) {
+                currentPackage.dependencies[dependency] = targetVersion;
+            }
+        }
+        for (const dependency in currentPackage.devDependencies) {
+            const currentValue = currentPackage.devDependencies[dependency];
+            if (dependency === otherPackage.name) {
+                currentPackage.devDependencies[dependency] = targetVersion;
+            }
+        }
+        for (const dependency in currentPackage.peerDependencies) {
+            const currentValue = currentPackage.peerDependencies[dependency];
+            if (dependency === otherPackage.name) {
+                currentPackage.peerDependencies[dependency] = targetVersion;
+            }
+        }        
+    }
+    const packageFile = path.resolve(packagesDirectory, i, 'package.json');
+    fs.writeFileSync(packageFile, JSON.stringify(currentPackage, null, 2), 'utf8');
+}
+
+const mechanizationVersionFileContents =`(*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*)
+
+(** This module defines Ergo version number *)
+
+Require Import String.
+
+Section Version.
+    Definition ergo_version := "${targetVersion}"%string.
+
+End Version.
+
+`;
+const mechanizationVersionFile = fs.writeFileSync(path.resolve(lernaDirectory, 'mechanization/Version.v'),mechanizationVersionFileContents, 'utf8');


### PR DESCRIPTION
Adding a release in GitHub will now trigger a travis build and publish to NPM.

Unlike the previous script the version number will be take from the GitHub Tag rather than autobumped at the patch level.

This is appropriate until we get to version 1.0.0 at which point we should switch to proper semantic versioning.