### PR TITLE
Remove ergop from CLI binaries

### DIFF
--- a/examples/acceptance-of-delivery/request.json
+++ b/examples/acceptance-of-delivery/request.json
@@ -1,5 +1,5 @@
 {
     "$class":"org.accordproject.acceptanceofdelivery.InspectDeliverable",
-    "deliverableReceivedAt": "25 Jun 2018 16:34:00 EST",
+    "deliverableReceivedAt": "8 Jul 2018 16:34:00 EST",
     "inspectionPassed": true
 }

--- a/packages/ergo-cli/package.json
+++ b/packages/ergo-cli/package.json
@@ -30,8 +30,7 @@
   },
   "bin": {
     "ergo": "./bin/ergo.js",
-    "ergoc": "./bin/ergoc.js",
-    "ergop": "./bin/ergop.js"
+    "ergoc": "./bin/ergoc.js"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
The Ergo CTO parser was moved https://github.com/accordproject/ergo/commit/ededf1cc5f6351300c800f296361790b6548a48f#diff-1ad374809c9a771eb804892b8f40016c but the reference in the ergo-cli package.json remained. This causes the npm installation to fail (#270 )