### PR TITLE
(fix) Not passing static context properly to next declaration #315

### DIFF
--- a/mechanization/Compiler/ErgoDriver.v
+++ b/mechanization/Compiler/ErgoDriver.v
@@ -94,7 +94,7 @@ Section ErgoDriver.
              let sctxt' := snd xy in
              elift
                (fun xy => (Some (fst xy), snd xy))
-               (ergoc_inline_declaration sctxt decl')
+               (ergoc_inline_declaration sctxt' decl')
            end)
       (ergo_declaration_to_ergoc sctxt decl).
 


### PR DESCRIPTION
Back to :
```
Welcome to ERGOTOP version 0.1.2
ergotop$ define function x() : Integer { return 1 }
ergotop$ return x();
Response. {"nat": 1.0}
```

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>