### PR TITLE
function type errors now displayed properly

### DIFF
--- a/mechanization/ErgoC/Lang/ErgoCType.v
+++ b/mechanization/ErgoC/Lang/ErgoCType.v
@@ -103,6 +103,12 @@ Section ErgoCType.
                 ergo_type_expr ctxt' e)
              (ergo_type_expr ctxt v))
     | ELet prov n (Some t) v e =>
+      let fmt_err :=
+          match prov with
+            | ProvFunc _ fname => ETypeError prov ("Incorrect type of arguments to function " ++ fname)
+            | _ => ETypeError prov "`Let' type mismatch"
+          end
+      in
       (eolift
          (fun vt =>
             let t' := (ergo_type_to_ergoc_type t) in
@@ -114,7 +120,7 @@ Section ErgoCType.
               in
               ergo_type_expr ctxt' e
             else
-              efailure (ETypeError prov "`Let' type mismatch."))
+              efailure fmt_err)
          (ergo_type_expr ctxt v))
     | ERecord prov rs =>
       fold_left

--- a/mechanization/Translation/ErgoCInline.v
+++ b/mechanization/Translation/ErgoCInline.v
@@ -87,7 +87,7 @@ Section ErgoCInline.
          | Some body =>
            match zip (fn.(functionc_sig).(sigc_params)) args with
            | Some args' =>
-             esuccess (ergo_letify_function' prov body args')
+             esuccess (ergo_letify_function' (ProvFunc (loc_of_provenance prov) fname) body args')
            | None =>
              call_params_error prov fname
            end

--- a/packages/ergo-cli/lib/ergoc-lib.js
+++ b/packages/ergo-cli/lib/ergoc-lib.js
@@ -10138,7 +10138,7 @@ d=[0,c];else
 var
 e=cA(an,NN,a),h=e?[0,e[1]]:[1,[0,b,g(Lz,g(a,Ly))]],d=h;return aU(function(c){var
 d=c[3];if(d){var
-e=kF(c[2][1],f);return e?[0,oX(b,d[1],e[1])]:[1,[2,b,g(Lx,g(a,Lw))]]}return[1,[0,b,g(LB,g(a,LA))]]},d)},NQ=function(e,a){switch(a[0]){case
+e=kF(c[2][1],f);return e?[0,oX([0,b[1],a],d[1],e[1])]:[1,[2,b,g(Lx,g(a,Lw))]]}return[1,[0,b,g(LB,g(a,LA))]]},d)},NQ=function(e,a){switch(a[0]){case
 12:var
 c=a[2],f=a[1],g=cA(an,e[2],c),k=g?oY(f,c,g[1],a[3]):k$(f,c);return[0,k];case
 13:var

--- a/packages/ergo-compiler/lib/ergo-core.js
+++ b/packages/ergo-compiler/lib/ergo-core.js
@@ -9975,7 +9975,7 @@ d=[0,c];else
 var
 e=cy(an,L9,a),h=e?[0,e[1]]:[1,[0,b,g(JV,g(a,JU))]],d=h;return aS(function(c){var
 d=c[3];if(d){var
-e=kb(c[2][1],f);return e?[0,ok(b,d[1],e[1])]:[1,[2,b,g(JT,g(a,JS))]]}return[1,[0,b,g(JX,g(a,JW))]]},d)},Ma=function(e,a){switch(a[0]){case
+e=kb(c[2][1],f);return e?[0,ok([0,b[1],a],d[1],e[1])]:[1,[2,b,g(JT,g(a,JS))]]}return[1,[0,b,g(JX,g(a,JW))]]},d)},Ma=function(e,a){switch(a[0]){case
 12:var
 c=a[2],f=a[1],g=cy(an,e[2],c),k=g?ol(f,c,g[1],a[3]):kH(f,c);return[0,k];case
 13:var


### PR DESCRIPTION
```
ergo$ define function f(x : Integer) : Integer { return x +i 1 }
ergo$ return 1.0 + f("cow");
[TypeError at line 1 col 13] Incorrect type of arguments to function org.accordproject.ergotop.f
return 1.0 + f("cow");
             ^^^^^^^^ 
ergo$ let x : Integer = "cow"; return x +i 1;
[TypeError at line 1 col 0] `Let' type mismatch
```