### PR TITLE
(fix) Switch order of parameters for arraySubtract on JS backends

### DIFF
--- a/examples/smoke/logic.ergo
+++ b/examples/smoke/logic.ergo
@@ -22,6 +22,7 @@ contract Smoke over TemplateModel {
     enforce(some(A{ a : 1 })?.a ?? 2 = 1);
     enforce(C{ contract : "foo" }.contract = "foo");
     enforce(C{ contract : "foo" }.contract = "foo");
+    enforce(arraySubtract([1,2,3],[2,3,4]) = [1]);
     return MyResponse{
       output: "Smoke.test successful"
     }

--- a/mechanization/Backend/Lib/ENNRCtoJavaScript.v
+++ b/mechanization/Backend/Lib/ENNRCtoJavaScript.v
@@ -414,7 +414,7 @@ End sanitizer.
                      | OpLt => `"(compare(" +++ e1 +++ `"," +++ e2 +++ `") < 0)" (* XXX Use compare! *)
                      | OpLe => `"(compare(" +++ e1 +++ `"," +++ e2 +++ `") <= 0)" (* XXX Use compare! *)
                      | OpBagUnion => `"bunion(" +++ e1 +++ `", " +++ e2 +++ `")"
-                     | OpBagDiff => `"bminus(" +++ e1 +++ `", " +++ e2 +++ `")"
+                     | OpBagDiff => `"bminus(" +++ e2 +++ `", " +++ e1 +++ `")"
                      | OpBagMin => `"bmin(" +++ e1 +++ `", " +++ e2 +++ `")"
                      | OpBagMax => `"bmax(" +++ e1 +++ `", " +++ e2 +++ `")"
                      | OpContains => `"contains(" +++ e1 +++ `", " +++ e2 +++ `")"

--- a/packages/ergo-cli/extracted/ergoccore.js
+++ b/packages/ergo-cli/extracted/ergoccore.js
@@ -11373,7 +11373,7 @@ bu=l(g,r(VE)),bv=l(f,l(r(VF),bu)),i=l(r(VG),bv);break;case
 7:var
 bw=l(g,r(VH)),bx=l(f,l(r(VI),bw)),i=l(r(VJ),bx);break;case
 8:var
-by=l(g,r(VK)),bz=l(f,l(r(VL),by)),i=l(r(VM),bz);break;case
+by=l(f,r(VK)),bz=l(g,l(r(VL),by)),i=l(r(VM),bz);break;case
 9:var
 bA=l(g,r(VN)),bB=l(f,l(r(VO),bA)),i=l(r(VP),bB);break;case
 10:var

--- a/packages/ergo-compiler/extracted/compilercore.js
+++ b/packages/ergo-compiler/extracted/compilercore.js
@@ -11185,7 +11185,7 @@ bu=l(g,r(Tn)),bv=l(f,l(r(To),bu)),i=l(r(Tp),bv);break;case
 7:var
 bw=l(g,r(Tq)),bx=l(f,l(r(Tr),bw)),i=l(r(Ts),bx);break;case
 8:var
-by=l(g,r(Tt)),bz=l(f,l(r(Tu),by)),i=l(r(Tv),bz);break;case
+by=l(f,r(Tt)),bz=l(g,l(r(Tu),by)),i=l(r(Tv),bz);break;case
 9:var
 bA=l(g,r(Tw)),bB=l(f,l(r(Tx),bA)),i=l(r(Ty),bB);break;case
 10:var


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>