### PR TITLE
docs(*): update markdown files and fix typos - I257

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Ergo
 
-> Thanks to the angularJS team for the bulk of this text!
+> Thanks to the AngularJS team for the bulk of this text!
 
 We'd love for you to contribute to our source code and to make Ergo even better than it is today! Here are the guidelines we'd like you to follow:
 
@@ -37,13 +37,13 @@ Other channels for support are:
 
 ###  Found an Issue or Bug?
 
-If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository](https://github.com/accordproject/ergo/issues). Even better, you can submit a Pull Request with a fix.
+If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github]. Even better, you can submit a Pull Request with a fix.
 
-**Please see the **[**Submission Guidelines**][contribute.submit]** below.**
+**Please see the [Submission Guidelines][contribute.submit] below.**
 
 ###  Missing a Feature?
 
-You can request a new feature by submitting an issue to our [GitHub Repository][github-issues].
+You can request a new feature by [submitting an issue][github-issues] to our GitHub Repository.
 
 If you would like to implement a new feature then consider what kind of change it is:
 
@@ -78,7 +78,7 @@ The "[new issue][github-new-issue]" form contains a number of prompts that you s
 Before you submit your pull request consider the following guidelines:
 
 * Ensure there is an open [Issue][github-issues] for what you will be working on. If there is not, open one up by going through [these guidelines][contribute.submit].
-* Search [GitHub][pulls] for an open or closed Pull Request that relates to your submission. You don't want to duplicate effort.
+* Search for an open or closed [Pull Request][pulls] that relates to your submission. You don't want to duplicate effort.
 * Create the [development environment][developers.setup]
 * Make your changes in a new git branch: ergo
 
@@ -96,7 +96,7 @@ Before you submit your pull request consider the following guidelines:
 * Follow our [Coding Rules][developers.rules].
 * Ensure you provide a DCO sign-off for your commits using the -s option of git commit. For more information see [how this works][dcohow].
 * If the changes affect public APIs, change or add relevant [documentation][developers.documentation].
-* Run the [unit][developers.unit-tests] test suite, and ensure that all tests pass.
+* Run the [unit test suite][developers.unit-tests], and ensure that all tests pass.
 
 * Commit your changes using a descriptive commit message that follows our [commit message conventions][developers.commits]. Adherence to the [commit message conventions][developers.commits] is required because release notes are automatically generated from these messages.
 
@@ -106,7 +106,7 @@ Before you submit your pull request consider the following guidelines:
 
   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
-* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-fowarding master:
+* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-forwarding master:
 
   ```text
     git rebase upstream/master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If you would like to implement a new feature then consider what kind of change i
   [GitHub issue][github-issues] that clearly outlines the changes and benefits of the feature.
 * **Small Changes** can directly be crafted and submitted to the [GitHub Repository][github]
   as a Pull Request. See the section about [Pull Request Submission Guidelines][contribute.submitpr] and
-  for detailed information the [core development documentation][developers].
+  for detailed information read the [core development documentation][developers].
 
 ###  Want a Doc Fix?
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -154,7 +154,7 @@ The subject contains succinct description of the change:
 * no dot (.) at the end
 
 ### Footer
-The footer should contain [reference GitHub Issues that this commit addresses][github-issues].
+The footer should contain [reference GitHub Issues][github-issues] that this commit addresses.
 
 ## <a name="pullrequests"></a> GitHub Pull Request Guidelines
 Pull Requests should consist of a complete addition to the code which contains value.
@@ -186,7 +186,7 @@ When approved and ready to merge, a Pull Request should be squashed down to a si
 
 ##  Writing Documentation
 
-The Ergo project uses [docusaurus][docusaurus] for the language documentation.
+The Ergo project uses [Docusaurus][docusaurus] for the language documentation.
 
 Code documentation uses the following tools:
 - [coq2html][coq2html] for the compiler specification (install with `opam install coq-coq2html`)


### PR DESCRIPTION
Signed-off-by: Michael Zhou <myz227@nyu.edu>

<OVERALL SUMMARY OF PULL REQUEST>
Updated markdown files by correcting for incorrect markdown links, integrating existing links into new markdown, and ensuring consistency in markdown style. Also fixes typos, grammar, and punctuation errors in documentation. All tests confirmed to pass.

### Changes
- Modified markdown to be more appropriate with content of associated links
- Fixed typos and miscellaneous errors in punctuation and grammar

### Related Issues
- [Cicero Template Library Issue 257](https://github.com/accordproject/cicero-template-library/issues/257)
- Pull Request [#280](https://github.com/accordproject/cicero-template-library/pull/280)