### PR TITLE
fix(format) Wrong ISO code for ¥ in JS runtime

### DIFF
--- a/backends/javascript/ergo-runtime.js
+++ b/backends/javascript/ergo-runtime.js
@@ -895,7 +895,7 @@ function codeSymbol(c) {
     case 'GBP' : return '£';
     case 'PLN' : return 'zł';
     case 'USD' : return '$';
-    case 'YEN' : return '¥';
+    case 'JPY' : return '¥';
     default : return c; // Defaults to ISO code
     }
 }


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>
