### PR TITLE
feature: pass arguments to contract init

### DIFF
--- a/packages/ergo-compiler/lib/logicmanager.js
+++ b/packages/ergo-compiler/lib/logicmanager.js
@@ -137,7 +137,7 @@ unwrapError(__result);
                 const contractName = this.getContractName();
                 code = `
 let contractObj = new ${contractName}();
-const __result = contractObj.${clauseName}(Object.assign({}, {__now:now,__options:options,__contract:context.data,__state:context.state,__emit:[]},context.params));
+const __result = contractObj.${clauseName}(Object.assign({}, {__now:now,__options:options,__contract:context.data,__state:context.state,__emit:[],request:context.request},context.params));
 unwrapError(__result);
 `;
             } else {
@@ -145,7 +145,7 @@ unwrapError(__result);
             }
         } else if (target === 'es5') {
             code = `
-const __result = ${clauseName}(Object.assign({}, {__now:now,__options:options,__contract:context.data,__state:context.state,__emit:[]},context.params));
+const __result = ${clauseName}(Object.assign({}, {__now:now,__options:options,__contract:context.data,__state:context.state,__emit:[],request:context.request},context.params));
 unwrapError(__result);
 `;
         } else {

--- a/packages/ergo-engine/lib/engine.js
+++ b/packages/ergo-engine/lib/engine.js
@@ -155,7 +155,7 @@ class Engine {
      * @param {object} options to the text generation
      * @return {object} the result for the clause
      */
-    invoke(logic, contractId, clauseName, contract, params, state, currentTime, options) {
+    invoke(logic, contractId, clauseName, contract, params, state, currentTime, options, request = {}) {
         // Set the current time and UTC Offset
         const now = Util.setCurrentTime(currentTime);
         const utcOffset = now.utcOffset();
@@ -168,6 +168,7 @@ class Engine {
         };
 
         const validContract = logic.validateContract(contract, options); // ensure the contract is valid
+        const validRequest = logic.validateInput(request); // ensure the request is valid
         const validParams = logic.validateInputRecord(params); // ensure the parameters are valid
         const validState = logic.validateInput(state); // ensure the state is valid
 
@@ -177,6 +178,7 @@ class Engine {
         const callScript = logic.getInvokeCall(clauseName);
         const context = {
             data: validContract.serialized,
+            request: request,
             state: validState,
             params: validParams
         };
@@ -208,12 +210,12 @@ class Engine {
      * @param {object} options to the text generation
      * @return {object} the result for the clause initialization
      */
-    init(logic, contractId, contract, params, currentTime, options) {
+    init(logic, contractId, contract, params, currentTime, options, request = {}) {
         const defaultState = {
             '$class':'org.accordproject.cicero.contract.AccordContractState',
             'stateId':'org.accordproject.cicero.contract.AccordContractState#1'
         };
-        return this.invoke(logic, contractId, 'init', contract, params, defaultState, currentTime, options);
+        return this.invoke(logic, contractId, 'init', contract, params, defaultState, currentTime, options, request);
     }
 
     /**

--- a/packages/ergo-engine/lib/engine.js
+++ b/packages/ergo-engine/lib/engine.js
@@ -153,6 +153,7 @@ class Engine {
      * using the Composer serializer.
      * @param {string} currentTime - the definition of 'now'
      * @param {object} options to the text generation
+     * @param {object} request - optional payload for the clause
      * @return {object} the result for the clause
      */
     invoke(logic, contractId, clauseName, contract, params, state, currentTime, options, request = {}) {
@@ -208,6 +209,7 @@ class Engine {
      * @param {object} params - the clause parameters
      * @param {string} currentTime - the definition of 'now'
      * @param {object} options to the text generation
+     * @param {object} request - optional payload for init clause
      * @return {object} the result for the clause initialization
      */
     init(logic, contractId, contract, params, currentTime, options, request = {}) {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #789 
<!--- Provide an overall summary of the pull request -->
LogicManager passes `request`s on to the VM Context and `engine.init` and `engine.invoke` have an optional parameter `request` which contains the request object.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- `LogicManager.getInvokeCall` passes `context.request` on (9849dd13fd7ad8e391e3531a1698894f2fc16aaa)
- `enine.invoke` adds `request` to `context` (b92240b005cd042cc80bf43dd454da221a942ef5) 

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- I tested this with empty init requests, but maybe there was a reason for not passing on `context.request`?

### Related Issues
- Issue #789 
- Issue https://github.com/accordproject/cicero/issues/604
