### PR TITLE
chore(dep) Upgrade Concerto to 1.0.0-alpha6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@accordproject/concerto-core": {
-			"version": "1.0.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.0.0-alpha.5.tgz",
-			"integrity": "sha512-SPjOldetWhUWUdkNdTZjYsWeRGVdayGF1CNIHPVPRnH5nilFQBFCMPbM5vudPfLxty6FKRMZMDcP4Ifm+A2jGQ==",
+			"version": "1.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.0.0-alpha.6.tgz",
+			"integrity": "sha512-lVWfYNpJ+cE/psx0g6ZrijAhFBd8n4VZEFBxBffD1i0tChJKMw+2X1EkJ1iKL2I0xiWxbneMWLhhpc9iSg3Bdg==",
 			"dev": true,
 			"requires": {
 				"axios": "0.21.1",
@@ -26,21 +26,6 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
 					"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 					"dev": true
 				}
 			}
@@ -3012,6 +2997,23 @@
 				"node-addon-api": "^1.7.1"
 			}
 		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"dev": true,
+			"requires": {
+				"ms": "^2.1.1"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+					"dev": true
+				}
+			}
+		},
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
@@ -5356,28 +5358,6 @@
 				"chalk": "^2.3.0",
 				"json-stringify-safe": "^5.0.1",
 				"yargs": "^11.0.0"
-			},
-			"dependencies": {
-				"yargs": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
-					"integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.1.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
-					}
-				}
 			}
 		},
 		"json-parse-better-errors": {
@@ -8409,6 +8389,26 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
 			"integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
 			"dev": true
+		},
+		"yargs": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
+			"integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.1.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^9.0.2"
+			}
 		},
 		"yargs-parser": {
 			"version": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@accordproject/concerto-core": "1.0.0-alpha.5",
+    "@accordproject/concerto-core": "1.0.0-alpha.6",
     "colors": "1.1.2",
     "coveralls": "3.0.1",
     "dayjs": "1.10.4",

--- a/packages/ergo-cli/extracted/ergotopcore.js
+++ b/packages/ergo-cli/extracted/ergotopcore.js
@@ -25834,7 +25834,7 @@ k=fz(c[1]);var
 D=xR(function(a,b){return a},k);jd(jc,ao(awg,ao(qL,awf)));function
 H(e,d,c){var
 b=awh(a,d,gz(c));return{"out":j9(b[1]),"ctx":b[2]}}var
-J={"initRCtxt":D,"version":j9(qL),"buildate":"Apr 12, 2021","runLine":axg(H)};return axf(0).ergotop=J},awv=function(g,a){var
+J={"initRCtxt":D,"version":j9(qL),"buildate":"Apr 13, 2021","runLine":axg(H)};return axf(0).ergotop=J},awv=function(g,a){var
 o=g[3],p=o?b_(o[1],g[4]):g[4];if(a[1]===m1)return new
 tj(j9(qK(p,a[2])));function
 t(e){var

--- a/packages/ergo-compiler/lib/boxedCollections.js
+++ b/packages/ergo-compiler/lib/boxedCollections.js
@@ -27,7 +27,7 @@ function boxColl(input) {
             $coll: coll,
             $length: input.length
         };
-    } else if (typeof input === 'object' && !(typeof input.isBefore === 'function')) {
+    } else if (input && typeof input === 'object' && !(typeof input.isBefore === 'function')) {
         if (Object.prototype.hasOwnProperty.call(input,'$class') &&
             !Object.prototype.hasOwnProperty.call(input,'$data')) {
             const theClass = [input.$class];

--- a/packages/ergo-compiler/package.json
+++ b/packages/ergo-compiler/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@accordproject/concerto-core": "1.0.0-alpha.5",
+    "@accordproject/concerto-core": "1.0.0-alpha.6",
     "acorn": "5.1.2",
     "dayjs": "1.10.4",
     "debug": "4.1.0",


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- Upgrade to latest Concerto `1.0.0-alpha.6`
- Makes dayjs test in boxing collection code more robust
