### PR TITLE
fix(core) Better handling for built-in Concerto models

### DIFF
--- a/packages/ergo-compiler/lib/apmodelmanager.js
+++ b/packages/ergo-compiler/lib/apmodelmanager.js
@@ -17,6 +17,7 @@
 const fsPath = require('path');
 
 const ModelManager = require('@accordproject/concerto-core').ModelManager;
+const Builtin = require('./builtin');
 
 /**
  * Accord Project Model Manager. Bootstraps the ModelManager with system files.
@@ -31,6 +32,11 @@ class APModelManager extends ModelManager {
      */
     constructor() {
         super();
+        this.addModelFile(Builtin.TimeModel, '@org.accordproject.time.cto');
+        this.addModelFile(Builtin.MoneyModel, '@org.accordproject.money.cto');
+        this.addModelFile(Builtin.ContractModel, '@org.accordproject.contract.cto');
+        this.addModelFile(Builtin.RuntimeModel, '@org.accordproject.runtime.cto');
+        this.validateModelFiles();
     }
 
     /**

--- a/packages/ergo-compiler/lib/ergoloader.js
+++ b/packages/ergo-compiler/lib/ergoloader.js
@@ -35,7 +35,6 @@ async function fromDirectory(path, options) {
     }
 
     const logicManager = new LogicManager('es6', options);
-    logicManager.addErgoBuiltin();
 
     const ctoFiles = await FileLoader.loadFilesContents(path, /model[/\\].*\.cto$/);
     ctoFiles.forEach((file) => {
@@ -78,7 +77,6 @@ async function fromZip(buffer, options) {
 
     const zip = await JSZip.loadAsync(buffer);
     const logicManager = new LogicManager('es6', options);
-    logicManager.addErgoBuiltin();
 
     const ctoFiles = await FileLoader.loadZipFilesContents(zip, /model[/\\].*\.cto$/);
     ctoFiles.forEach((file) => {
@@ -117,7 +115,6 @@ async function fromFiles(files, options) {
     }
 
     const logicManager = new LogicManager('es6', options);
-    logicManager.addErgoBuiltin();
 
     let modelPaths = [];
     let logicPaths = [];

--- a/packages/ergo-compiler/test/logicmanager.js
+++ b/packages/ergo-compiler/test/logicmanager.js
@@ -58,16 +58,28 @@ describe('LogicManager', () => {
             const logicManager = new LogicManager('es6');
             logicManager.addModelFile(ctoSample,'test.cto');
             const modelManager = logicManager.getModelManager();
-            modelManager.getModels().map(x => x.name).should.deep.equal(['test.cto']);
-            modelManager.getModels()[0].content.length.should.equal(175);
+            modelManager.getModels().map(x => x.name).should.deep.equal([
+                '@org.accordproject.time.cto',
+                '@org.accordproject.money.cto',
+                '@org.accordproject.contract.cto',
+                '@org.accordproject.runtime.cto',
+                'test.cto'
+            ]);
+            modelManager.getModels()[4].content.length.should.equal(175);
         });
 
         it('should load a model to the model manager (bulk)', () => {
             const logicManager = new LogicManager('es6');
             logicManager.addModelFiles([ctoSample],['test.cto']);
             const modelManager = logicManager.getModelManager();
-            modelManager.getModels().map(x => x.name).should.deep.equal(['test.cto']);
-            modelManager.getModels()[0].content.length.should.equal(175);
+            modelManager.getModels().map(x => x.name).should.deep.equal([
+                '@org.accordproject.time.cto',
+                '@org.accordproject.money.cto',
+                '@org.accordproject.contract.cto',
+                '@org.accordproject.runtime.cto',
+                'test.cto'
+            ]);
+            modelManager.getModels()[4].content.length.should.equal(175);
         });
 
         it('should load a logic file to the script manager', () => {
@@ -194,7 +206,6 @@ describe('LogicManager', () => {
 
         it('should load a logic file to the script manager (with Ergo builtin)', () => {
             const logicManager = new LogicManager('es6');
-            logicManager.addErgoBuiltin();
             logicManager.addLogicFile(ergoSample,'test3.ergo');
             logicManager.compileLogicSync(false);
             logicManager.getInvokeCall('helloworld').length.should.equal(231);
@@ -268,8 +279,14 @@ describe('LogicManager', () => {
             const logicManager = new LogicManager('es6');
             const modelManager = logicManager.getModelManager();
             modelManager.addModelFile(ctoSample,null,true);
-            modelManager.getModels().map(x => x.name).should.deep.equal(['org.accordproject.copyrightlicense.cto']);
-            modelManager.getModels()[0].content.length.should.equal(175);
+            modelManager.getModels().map(x => x.name).should.deep.equal([
+                '@org.accordproject.time.cto',
+                '@org.accordproject.money.cto',
+                '@org.accordproject.contract.cto',
+                '@org.accordproject.runtime.cto',
+                'org.accordproject.copyrightlicense.cto'
+            ]);
+            modelManager.getModels()[4].content.length.should.equal(175);
         });
     });
 
@@ -385,22 +402,47 @@ describe('LogicManager', () => {
         it('should update a model to the model manager', () => {
             const modelManager = logicManager.getModelManager();
             logicManager.updateModel(ctoSample,'test.cto');
-            modelManager.getModels().map(x => x.name).should.deep.equal(['test.cto']);
-            modelManager.getModels()[0].content.length.should.equal(175);
+            modelManager.getModels().map(x => x.name).should.deep.equal([
+                '@org.accordproject.time.cto',
+                '@org.accordproject.money.cto',
+                '@org.accordproject.contract.cto',
+                '@org.accordproject.runtime.cto',
+                'test.cto'
+            ]);
+            modelManager.getModels()[4].content.length.should.equal(175);
             logicManager.updateModel(ctoSample3,'test.cto');
-            modelManager.getModels().map(x => x.name).should.deep.equal(['test.cto']);
-            modelManager.getModels()[0].content.length.should.equal(369);
+            modelManager.getModels().map(x => x.name).should.deep.equal([
+                '@org.accordproject.time.cto',
+                '@org.accordproject.money.cto',
+                '@org.accordproject.contract.cto',
+                '@org.accordproject.runtime.cto',
+                'test.cto'
+            ]);
+            modelManager.getModels()[4].content.length.should.equal(369);
             logicManager.updateModel(ctoSample2,'test.cto');
-            modelManager.getModels().map(x => x.name).should.deep.equal(['test.cto']);
-            modelManager.getModels()[0].content.length.should.equal(173);
+            modelManager.getModels().map(x => x.name).should.deep.equal([
+                '@org.accordproject.time.cto',
+                '@org.accordproject.money.cto',
+                '@org.accordproject.contract.cto',
+                '@org.accordproject.runtime.cto',
+                'test.cto'
+            ]);
+            modelManager.getModels()[4].content.length.should.equal(173);
         });
 
         it('should add a model to the model manager', () => {
             const modelManager = logicManager.getModelManager();
             logicManager.updateModel(ctoSample2,'test2.cto');
-            modelManager.getModels().map(x => x.name).should.deep.equal(['test.cto','test2.cto']);
-            modelManager.getModels()[0].content.length.should.equal(175);
-            modelManager.getModels()[1].content.length.should.equal(173);
+            modelManager.getModels().map(x => x.name).should.deep.equal([
+                '@org.accordproject.time.cto',
+                '@org.accordproject.money.cto',
+                '@org.accordproject.contract.cto',
+                '@org.accordproject.runtime.cto',
+                'test.cto',
+                'test2.cto'
+            ]);
+            modelManager.getModels()[4].content.length.should.equal(175);
+            modelManager.getModels()[5].content.length.should.equal(173);
         });
 
         it('should update a logic file in the script manager', () => {

--- a/packages/ergo-engine/test/commonengine.js
+++ b/packages/ergo-engine/test/commonengine.js
@@ -97,7 +97,6 @@ function runWorkload(Engine, target) {
     beforeEach(async function () {
         engine = new Engine();
         logicManager = new LogicManager(target, null);
-        logicManager.addErgoBuiltin();
     });
 
     afterEach(() => {});

--- a/packages/ergo-test/lib/steps.js
+++ b/packages/ergo-test/lib/steps.js
@@ -69,7 +69,6 @@ Before(function () {
     this.utcOffset = 0;
     this.logicManager = new LogicManager('es6', null);
     this.state = defaultState;
-    this.logicManager.addErgoBuiltin();
 });
 
 Given('the target platform {string}', function (target) {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- Cleans up handling of built-in Concerto models, avoiding odd external `addErgoBuiltIn` calls on the model manager

