### PR TITLE
fix(docs): Update Slack to Discord - #388 and feat(cicero): Returning the validated request -#643

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/accordproject/ergo?color=bright-green" alt="GitHub license"></a>
   <a href="https://www.npmjs.com/package/@accordproject/ergo-cli"><img src="https://img.shields.io/npm/dm/@accordproject/ergo-cli" alt="downloads"></a>
   <a href="https://badge.fury.io/js/%40accordproject%2Fergo-cli"><img src="https://badge.fury.io/js/%40accordproject%2Fergo-cli.svg" alt="npm version"></a>
-  <a href="https://accord-project-slack-signup.herokuapp.com/">
-    <img src="https://img.shields.io/badge/Accord%20Project-Join%20Slack-blue" alt="Join the Accord Project Slack"/>
-  </a>
+
 </p>
 
 ## Introduction
@@ -160,9 +158,7 @@ the compiled JavaScript code in `./tests/volumediscount/logic.js`
   <a href="./LICENSE">
     <img src="https://img.shields.io/github/license/accordproject/cicero?color=bright-green" alt="GitHub license">
   </a>
-  <a href="https://accord-project-slack-signup.herokuapp.com/">
-    <img src="https://img.shields.io/badge/Accord%20Project-Join%20Slack-blue" alt="Join the Accord Project Slack"/>
-  </a>
+ 
 </p>
 
 Accord Project is an open source, non-profit, initiative working to transform contract management and contract automation by digitizing contracts. Accord Project operates under the umbrella of the [Linux Foundation][linuxfound]. The technical charter for the Accord Project can be found [here][charter].
@@ -179,7 +175,7 @@ The Accord Project technology is being developed as open source. All the softwar
 
 Find out what’s coming on our [blog][apblog].
 
-Join the Accord Project Technology Working Group [Slack channel][apslack] to get involved!
+Join the Accord Project Technology Working Group [Discord channel][apdesc] to get involved!
 
 For code contributions, read our [CONTRIBUTING guide][contributing] and information for [DEVELOPERS][developers].
 
@@ -210,3 +206,5 @@ Copyright 2018-2019 Clause, Inc. All trademarks are the property of their respec
 
 [apache]: https://github.com/accordproject/ergo/blob/master/LICENSE
 [creativecommons]: http://creativecommons.org/licenses/by/4.0/
+[apdesc]: https://discord.gg/Zm99SKhhtA
+

--- a/packages/ergo-engine/lib/engine.js
+++ b/packages/ergo-engine/lib/engine.js
@@ -160,13 +160,14 @@ class Engine {
 
         // execute the logic
         const result = this.runVMScriptCall(offset,now,validOptions,context,script,callScript);
+        const validRequest = validateES6.validateOutput(modelManager,result.request,offset)// now ensuring the request is also valid
         const validResponse = validateES6.validateOutput(modelManager, result.__response, offset); // ensure the response is valid
         const validNewState = validateES6.validateOutput(modelManager, result.__state, offset); // ensure the new state is valid
         const validEmit = validateES6.validateOutputArray(modelManager, result.__emit, offset); // ensure all the emits are valid
 
         const answer = {
             'clause': contractId,
-            'request': request, // Keep the original request
+            'request':  validRequest, // Keep the original request
             'response': validResponse,
             'state': validNewState,
             'emit': validEmit,
@@ -218,7 +219,7 @@ class Engine {
         };
 
         // execute the logic
-        const result = this.runVMScriptCall(offset,now,validOptions,context,script,callScript);
+        const result = this.runVMScriptCall(offset,now,validOptions,context,script,callScript); 
         const validResponse = validateES6.validateOutput(modelManager, result.__response, offset); // ensure the response is valid
         const validNewState = validateES6.validateOutput(modelManager, result.__state, offset); // ensure the new state is valid
         const validEmit = validateES6.validateOutputArray(modelManager, result.__emit, offset); // ensure all the emits are valid


### PR DESCRIPTION
Signed-off-by: tech-bash airiraghav@gmail.com

# Closes #847 and   #643 of the cicero issue 

### Changes
1- Changed slack link to discord link of ergo/readme.md
2-  Added the feature of returning the validated request rather than the input one ... in engine.js .


### Related Issues
- Issues -> #847   and
- ->[Contract execution should return the validated request instead of the input request #643](https://github.com/accordproject/cicero/issues/643)


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
