### PR TITLE
fix(README): change slack references to discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 We'd love for you to contribute to our source code and to make Ergo technology even better than it is today! Please refer to the [Accord Project Contribution guidelines][apcontribute] we'd like you to follow.
 
 ## Ergo Specific Information
-The main channel for support with Ergo is the [Ergo Slack Channel][apergoslack] on the [Accord Project slack][apslack].
+The main channel for support with Ergo is the [Ergo Discord Channel][apergodiscord] on the [Accord Project Discord Server][apdiscord].
 
 [apcontribute]: https://github.com/accordproject/techdocs/blob/master/CONTRIBUTING.md
-[apslack]: https://accord-project-slack-signup.herokuapp.com	
-[apergoslack]: https://accord-project.slack.com/messages/C9HLJHREG/
+[apdiscord]: https://discord.gg/Zm99SKhhtA/
+[apergodiscord]: https://discord.com/channels/874841541787656263/874874462447738911/

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -26,7 +26,7 @@ Before you can build Ergo, you must install and configure the following prerequi
 * [Lerna](https://lerna.js.org): We use lerna to handle multiple npm packages in the Ergo repository. To install:
 
 ```sh
-$ npm install -g lerna@^3.15.0
+$ npm install -g lerna@^4.0.0
 ```
 
 * [opam](https://opam.ocaml.org): the OCaml package manager, for OCaml 4.11.2. To install:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/accordproject/ergo?color=bright-green" alt="GitHub license"></a>
   <a href="https://www.npmjs.com/package/@accordproject/ergo-cli"><img src="https://img.shields.io/npm/dm/@accordproject/ergo-cli" alt="downloads"></a>
   <a href="https://badge.fury.io/js/%40accordproject%2Fergo-cli"><img src="https://badge.fury.io/js/%40accordproject%2Fergo-cli.svg" alt="npm version"></a>
-  <a href="https://accord-project-slack-signup.herokuapp.com/">
-    <img src="https://img.shields.io/badge/Accord%20Project-Join%20Slack-blue" alt="Join the Accord Project Slack"/>
+  <a href="https://discord.gg/Zm99SKhhtA/">
+    <img src="https://img.shields.io/badge/Accord%20Project-Join%20Discord-blue" alt="Join the Accord Project Discord Server"/>
   </a>
 </p>
 
@@ -160,8 +160,8 @@ the compiled JavaScript code in `./tests/volumediscount/logic.js`
   <a href="./LICENSE">
     <img src="https://img.shields.io/github/license/accordproject/cicero?color=bright-green" alt="GitHub license">
   </a>
-  <a href="https://accord-project-slack-signup.herokuapp.com/">
-    <img src="https://img.shields.io/badge/Accord%20Project-Join%20Slack-blue" alt="Join the Accord Project Slack"/>
+  <a href="https://discord.gg/Zm99SKhhtA">
+    <img src="https://img.shields.io/badge/Accord%20Project-Join%20Discord-blue" alt="Join the Accord Project Discord Server"/>
   </a>
 </p>
 
@@ -179,7 +179,7 @@ The Accord Project technology is being developed as open source. All the softwar
 
 Find out what’s coming on our [blog][apblog].
 
-Join the Accord Project Technology Working Group [Slack channel][apslack] to get involved!
+Join the Accord Project Technology Working Group [Discord Server][apdiscord] to get involved!
 
 For code contributions, read our [CONTRIBUTING guide][contributing] and information for [DEVELOPERS][developers].
 
@@ -203,7 +203,7 @@ Copyright 2018-2019 Clause, Inc. All trademarks are the property of their respec
 [apmain]: https://accordproject.org/ 
 [apblog]: https://medium.com/@accordhq
 [apdoc]: https://docs.accordproject.org/
-[apslack]: https://accord-project-slack-signup.herokuapp.com
+[apdiscord]: https://discord.gg/Zm99SKhhtA 
 
 [contributing]: https://github.com/accordproject/ergo/blob/master/CONTRIBUTING.md
 [developers]: https://github.com/accordproject/ergo/blob/master/DEVELOPERS.md


### PR DESCRIPTION
Signed-off-by: Martin Halford <martin@benext.io>

### Changes

1.  README.md - Changed references from Slack to Discord (including the shields.io image badge).
2. DEVELOPERS.md - Bumped reference to `lerna@^3.15.0` up to version currently being used `lerna@^4.0.0`3. 
3. CONTRIBUTING.md - Changed references from Slack to Discord
