### PR TITLE
feature(engine): trigger now returns the concerto validated JSON for …

### DIFF
--- a/packages/ergo-engine/lib/engine.js
+++ b/packages/ergo-engine/lib/engine.js
@@ -160,13 +160,14 @@ class Engine {
 
         // execute the logic
         const result = this.runVMScriptCall(offset,now,validOptions,context,script,callScript);
+        const outputRequest = validateES6.validateStandard(modelManager, request, offset);
         const validResponse = validateES6.validateOutput(modelManager, result.__response, offset); // ensure the response is valid
         const validNewState = validateES6.validateOutput(modelManager, result.__state, offset); // ensure the new state is valid
         const validEmit = validateES6.validateOutputArray(modelManager, result.__emit, offset); // ensure all the emits are valid
 
         const answer = {
             'clause': contractId,
-            'request': request, // Keep the original request
+            'request': outputRequest,
             'response': validResponse,
             'state': validNewState,
             'emit': validEmit,

--- a/packages/ergo-engine/lib/validateES6.js
+++ b/packages/ergo-engine/lib/validateES6.js
@@ -64,6 +64,27 @@ function validateInput(modelManager, input, utcOffset) {
 }
 
 /**
+ * Validate standard
+ * @param {object} modelManager - the Concerto model manager
+ * @param {object} input - the input JSON
+ * @param {number} utcOffset - UTC Offset for DateTime values
+ * @return {object} the validated input
+ */
+function validateStandard(modelManager, input, utcOffset) {
+    const factory = new Factory(modelManager);
+    const serializer = new Serializer(factory, modelManager);
+
+    if (input === null) { return null; }
+
+    // ensure the input is valid
+    const validInput = serializer.fromJSON(input, {validate: false, acceptResourcesForRelationships: true, utcOffset});
+    validInput.$validator = new ResourceValidator({permitResourcesForRelationships: true});
+    validInput.validate();
+    const vJson = serializer.toJSON(validInput, {permitResourcesForRelationships:true, utcOffset});
+    return vJson;
+}
+
+/**
  * Validate input JSON record
  * @param {object} modelManager - the Concerto model manager
  * @param {object} input - the input JSON record
@@ -123,6 +144,7 @@ function validateOutputArray(modelManager, output, utcOffset) {
 }
 
 module.exports = {
+    validateStandard,
     validateContract,
     validateInput,
     validateInputRecord,


### PR DESCRIPTION
…the request

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- Ergo execution now returns the Concerto validated request rather than the raw input JSON

### Flags

- Semantic change as proposed in the Cicero issue: https://github.com/accordproject/cicero/issues/643

